### PR TITLE
devops: Reduce interval at which dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "chore:"
   # Python
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "chore:"


### PR DESCRIPTION
Daily update checks tends to be a bit much, as there're many dependencies that're pushed all the time :D.
Personally, I find the influx of MRs a bit annoying, as there's no need to be ultra up-to-date. Monthly bumps should be more than enough :).

Feel free to close this though. I don't get notifications for this repository anyway, so I'm not too bothered about this :D